### PR TITLE
Ensure CTA is still clickable

### DIFF
--- a/frontend21/scss/components/content/stage.scss
+++ b/frontend21/scss/components/content/stage.scss
@@ -50,6 +50,7 @@
     margin-bottom: var(--spacing);
     overflow: hidden;
     padding-bottom: 105%;
+    z-index: 0;
 
     amp-img img {
       object-fit: cover;


### PR DESCRIPTION
**summary**
At mid-size viewports on https://amp.dev/about/websites/, the CTA "Get started with AMP" is not clickable. I believe this PR fixes it, although please feel free to make a different fix and/or commandeer this PR.

![Screen Shot 2021-10-20 at 10 21 52 AM](https://user-images.githubusercontent.com/4656974/138111710-ba22bffb-1bc9-4fd4-9963-25999a159c97.png)

